### PR TITLE
Allow syscalls used by delve debugger

### DIFF
--- a/com.jetbrains.GoLand.yaml
+++ b/com.jetbrains.GoLand.yaml
@@ -16,6 +16,7 @@ finish-args:
   - --filesystem=xdg-run/keyring
   - --device=all
   - --env=GOLAND_JDK=${FLATPAK_DEST}/goland/jbr/
+  - --allow=devel
 modules:
   - name: goland
     buildsystem: simple


### PR DESCRIPTION
Go debugger delve used in Goland needs to perform some syscalls (ptrace I suppose) in order to works.

Adding devel mode by default.

Closes #7 