### PR TITLE
Allow access to Podman socket

### DIFF
--- a/com.jetbrains.GoLand.yaml
+++ b/com.jetbrains.GoLand.yaml
@@ -14,6 +14,7 @@ finish-args:
   - --talk-name=org.freedesktop.secrets
   - --filesystem=xdg-run/keyring
   - --filesystem=xdg-run/gnupg:ro
+  - --filesystem=xdg-run/podman  
   - --device=all
   - --env=GOLAND_JDK=${FLATPAK_DEST}/goland/jbr/
   - --allow=devel


### PR DESCRIPTION
This adds permission to connect to podman and use it as a container engine.

A podman.socket needs to be running and a docker.sock link needs to be created:
systemctl --user enable --now podman.socket
ln -s /run/user/$(id -u)/podman/podman.sock /var/run/user/$(id -u)/docker.sock

Then add a Unix rootless service in GoLand. The link is needed as GoLand still use docker.sock naming instead of podman.sock.