### PR TITLE
Add libsecret

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.jetbrains.GoLand.yaml
+++ b/com.jetbrains.GoLand.yaml
@@ -18,6 +18,8 @@ finish-args:
   - --env=GOLAND_JDK=${FLATPAK_DEST}/goland/jbr/
   - --allow=devel
 modules:
+  - shared-modules/libsecret/libsecret.json
+
   - modules/rsync.yml
 
   - name: goland


### PR DESCRIPTION
Libsecret is necessary for jetbrains IDEs to store passwords in the native keychain.
Currently, this error occurs when trying to use the native keychain:
![image](https://user-images.githubusercontent.com/10004812/207236417-5164e7d3-6001-4fd1-8edd-7e42053e15d8.png)

Adding libsecret to this flatpak would resolve this issue.