### PR TITLE
Adds more permissions to allow using system services running in the host

### DIFF
--- a/com.jetbrains.GoLand.yaml
+++ b/com.jetbrains.GoLand.yaml
@@ -6,12 +6,18 @@ command: goland.sh
 separate-locales: false
 finish-args:
   - --share=ipc
-  - --socket=x11
   - --share=network
+  - --socket=gpg-agent
   - --socket=pulseaudio
+  - --socket=ssh-auth
+  - --socket=wayland
+  - --socket=x11
   - --filesystem=host
+  - --talk-name=org.freedesktop.Flatpak
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.gnome.keyring.SystemPrompter
+  - --filesystem=host
   - --filesystem=xdg-run/keyring
   - --filesystem=xdg-run/gnupg:ro
   - --device=all


### PR DESCRIPTION
Hello, to allow a better user experience, this PR adds:

- access to the wayland, gpg-agent, and ssh-auth sockets;
- permissions to communicate with Flatpak's API and to execute commands in the host (e.g., spawning a shell from the terminal window with `flatpak-spawn --host`);
- permissions to communicate with the Gnome's SystemPrompter API 

Is this something reasonable to accept here?