### PR TITLE
Revert "Update goland.tar.gz to 2023.1"

### DIFF
--- a/com.jetbrains.GoLand.metainfo.xml
+++ b/com.jetbrains.GoLand.metainfo.xml
@@ -21,7 +21,6 @@
 	<url type="help">https://www.jetbrains.com/help/go/</url>
 	<launchable type="desktop-id">com.jetbrains.GoLand.desktop</launchable>
 	<releases>
-		<release version="2023.1" date="2023-04-03"/>
 		<release version="2022.3.4" date="2023-03-24"/>
 		<release version="2022.3.3" date="2023-03-09"/>
 		<release version="2022.3.2" date="2023-01-30"/>

--- a/com.jetbrains.GoLand.yaml
+++ b/com.jetbrains.GoLand.yaml
@@ -36,8 +36,8 @@ modules:
         "${icon_out}" -t "${FLATPAK_DEST}/share/icons/hicolor/${s}x${s}/apps/"; done;
     sources:
       - type: file
-        url: https://download.jetbrains.com/go/goland-2023.1.tar.gz
-        sha256: f208e2471ef5c4e232ff49434e8c14ce614b7924963ebd28d4c863399dd42d2c
+        url: https://download.jetbrains.com/go/goland-2022.3.4.tar.gz
+        sha256: f8ff96336c416ab56abea03819cb3637a1d46b80a88e8544f1e9e98746b781ac
         x-checker-data:
           type: jetbrains
           code: GO


### PR DESCRIPTION
Reverts flathub/com.jetbrains.GoLand#64

2023.1 runs chrome in a sandbox. Additional configuration is needed for it to work. Reverting for now. Will work on a fix later.
Closes #65 