### PR TITLE
Replace script launcher with native one

### DIFF
--- a/com.jetbrains.GoLand.yaml
+++ b/com.jetbrains.GoLand.yaml
@@ -2,7 +2,7 @@ app-id: com.jetbrains.GoLand
 runtime: org.freedesktop.Sdk
 runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
-command: goland.sh
+command: goland
 separate-locales: false
 finish-args:
   - --share=ipc


### PR DESCRIPTION
I noticed that there was a little warning when running Goland in the startup window. Advising to switch to native command `goland` instead of the wrapper script `goland.sh`

Here is the documentation from Jetbrain https://youtrack.jetbrains.com/articles/SUPPORT-A-56/How-to-handle-Switch-to-a-native-launcher-notification